### PR TITLE
Add Example .dev_properties.json file.

### DIFF
--- a/.dev_properties.json.example
+++ b/.dev_properties.json.example
@@ -1,0 +1,7 @@
+{
+  "username": "example",
+  "password": "secret",
+  "domain": "example.com",
+  "siteName": "example",
+  "addonName": "example"
+}


### PR DESCRIPTION
Adding a .dev_properties.json.example file to simplify the process of running create-addon without having to dive into the "specifics" of what data it needs to be run.