### PR TITLE
Add Support of siteNames that has to be URL-encoded.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "inquirer": "^5.2.0",
     "jsonfile": "^4.0.0",
-    "qs-iconv": "^1.0.4",
     "request": "^2.85.0",
     "zip-dir": "^1.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   "homepage": "https://github.com/sitevision/restapp-boilerplate#readme",
   "devDependencies": {
     "inquirer": "^5.2.0",
-    "zip-dir": "^1.0.2",
     "jsonfile": "^4.0.0",
-    "request": "^2.85.0"
+    "qs-iconv": "^1.0.4",
+    "request": "^2.85.0",
+    "zip-dir": "^1.0.2"
   }
 }

--- a/util/create-addon.js
+++ b/util/create-addon.js
@@ -1,7 +1,7 @@
 var
-   queryString   = require('querystring');
    request       = require('request');
    properties    = require('../util/properties');
+   queryString   = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),

--- a/util/create-addon.js
+++ b/util/create-addon.js
@@ -1,12 +1,9 @@
 var
-   qsIconv       = require('qs-iconv');
    queryString   = require('querystring');
    request       = require('request');
    properties    = require('../util/properties');
 
 (function () {
-   queryString.escape = qsIconv.encoder('win1250');
-
    var props = properties.getDevProperties(),
       url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${queryString.escape(props.siteName)}/Addon%20Repository/headlesscustommodule`;
 

--- a/util/create-addon.js
+++ b/util/create-addon.js
@@ -1,10 +1,14 @@
 var
+   qsIconv       = require('qs-iconv');
+   queryString   = require('querystring');
    request       = require('request');
    properties    = require('../util/properties');
 
 (function () {
+   queryString.escape = qsIconv.encoder('win1250');
+
    var props = properties.getDevProperties(),
-      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${props.siteName}/Addon%20Repository/headlesscustommodule`;
+      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${queryString.escape(props.siteName)}/Addon%20Repository/headlesscustommodule`;
 
    request.post({url: url, form: {name: props.addonName, category: 'Other'}}, (err, httpResponse, body) => {
       if (err) {

--- a/util/deploy.js
+++ b/util/deploy.js
@@ -4,10 +4,11 @@ var
    fs            = require('fs'),
    request       = require('request');
    properties    = require('../util/properties');
+   queryString   = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),
-      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${props.siteName}/Addon%20Repository/${props.addonName}/restAppImport`,
+      url = `https://${props.username}:${props.password}@${props.domain}/rest-api/1/0/${queryString.escape(props.siteName)}/Addon%20Repository/${props.addonName}/restAppImport`,
       manifest = properties.getManifest(),
       formData = {
          file: fs.createReadStream(properties.DIST_DIR_PATH + '/' + manifest.id + '.zip')
@@ -25,7 +26,7 @@ var
       if (httpResponse.statusCode === 200) {
          return console.log('Upload successful: \n', JSON.stringify(JSON.parse(body), null, 2));
       }
-      
+
       console.log('Upload failed: \n', JSON.stringify(JSON.parse(body), null, 2));
    });
 })();

--- a/util/prod-deploy.js
+++ b/util/prod-deploy.js
@@ -3,6 +3,7 @@ var
    fs          = require('fs'),
    request     = require('request'),
    properties  = require('../util/properties');
+   queryString = require('querystring');
 
 (function () {
    var props = properties.getDevProperties(),
@@ -34,7 +35,7 @@ var
       ];
 
    inquirer.prompt(questions).then(answers => {
-      var url = `https://${answers.username}:${answers.password}@${answers.domain}/rest-api/1/0/${answers.siteName}/Addon%20Repository/${answers.addonName}/restAppImport`,
+      var url = `https://${answers.username}:${answers.password}@${answers.domain}/rest-api/1/0/${queryString.escape(answers.siteName)}/Addon%20Repository/${answers.addonName}/restAppImport`,
          manifest = properties.getManifest(),
          formData = {
             file: fs.createReadStream(properties.DIST_DIR_PATH + '/' + manifest.id + '-signed.zip')


### PR DESCRIPTION
Adds support for allowing site names that has to be URL-encoded to run create-addon (this includes names containing åäö) without the need to enter the URL-encoded version during setup.